### PR TITLE
fix(preview): line break skills list when the line is completelly occupied

### DIFF
--- a/src/components/previews/Preview.svelte
+++ b/src/components/previews/Preview.svelte
@@ -5,7 +5,7 @@
     coreSkills,
     frontendSkills,
     backendSkills,
-  } from "../../stores";
+  } from '../../stores';
 
   $: name = $basicInfo[0].value;
   $: subtitle = $basicInfo[1].value;
@@ -58,7 +58,7 @@
   </div>
 
   <!-- SKILLS -->
-  <div class="flex justify-start items-center gap-2 my-2">
+  <div class="flex justify-start items-center gap-2 my-2 flex-wrap">
     {#each $coreSkills as skill (skill.key)}
       {#if skill.value == true}
         <img class="w-6 mx-1" alt={skill.alt} src={skill.img} />


### PR DESCRIPTION
Hey what's up?!

 This PR fixes the preview of skills list when the selected skills occupies more than one line.

  A comparison between before and after this fix:
  
![image](https://user-images.githubusercontent.com/52766091/214717472-738ba763-c28d-4963-bae4-b49688316f68.png)
 
